### PR TITLE
Added missing extern and added function type to compile properly on OSX

### DIFF
--- a/src/action.c
+++ b/src/action.c
@@ -66,7 +66,7 @@ static bool actionHandler(Webs *wp)
 /*
     Define a function in the "action" map space
  */
-PUBLIC int websDefineAction(char *name, WebsActionFunction *fn)
+PUBLIC int websDefineAction(char *name, void *fn)
 {
     assert(name && *name);
     assert(fn);

--- a/src/action.c
+++ b/src/action.c
@@ -66,7 +66,7 @@ static bool actionHandler(Webs *wp)
 /*
     Define a function in the "action" map space
  */
-PUBLIC int websDefineAction(char *name, void *fn)
+PUBLIC int websDefineAction(char *name, WebsActionFunction *fn)
 {
     assert(name && *name);
     assert(fn);

--- a/src/goahead.h
+++ b/src/goahead.h
@@ -1750,12 +1750,6 @@ typedef void (*WebsAction)(Webs *wp);
 #endif
 
 /**
-    websDefineAction function type
-*/
-typedef void (WebsActionFunction)(Webs *wp);
-
-
-/**
     Error code list
     @ingroup Webs
  */
@@ -2443,7 +2437,7 @@ PUBLIC void websPump(Webs *wp);
     @return Zero if successful, otherwise -1.
     @ingroup Webs
  */
-PUBLIC int websDefineAction(char *name, WebsActionFunction fun);
+PUBLIC int websDefineAction(char *name, void *fun);
 
 /**
     Read data from an open file

--- a/src/goahead.h
+++ b/src/goahead.h
@@ -12,6 +12,11 @@
 #include    "me.h"
 #include    "osdep.h"
 
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
 #if (ME_COM_EST + ME_COM_MATRIXSSL + ME_COM_NANOSSL + ME_COM_OPENSSL) > 1
     #error "Cannot have more than one SSL provider configured"
 #endif
@@ -1745,6 +1750,12 @@ typedef void (*WebsAction)(Webs *wp);
 #endif
 
 /**
+    websDefineAction function type
+*/
+typedef void (WebsActionFunction)(Webs *wp);
+
+
+/**
     Error code list
     @ingroup Webs
  */
@@ -2432,7 +2443,7 @@ PUBLIC void websPump(Webs *wp);
     @return Zero if successful, otherwise -1.
     @ingroup Webs
  */
-PUBLIC int websDefineAction(char *name, void *fun);
+PUBLIC int websDefineAction(char *name, WebsActionFunction fun);
 
 /**
     Read data from an open file


### PR DESCRIPTION
When integrated with C++, I found these changes enabled me to embed GoAhead into my application on OS X.