### PR TITLE
Fix null pointer dereferences and add integer overflow check

### DIFF
--- a/src/cgi.c
+++ b/src/cgi.c
@@ -130,6 +130,7 @@ PUBLIC bool cgiHandler(Webs *wp)
      */
     argpsize = 10;
     argp = walloc(argpsize * sizeof(char *));
+    assert(argp);
     *argp = cgiPath;
     n = 1;
     query = 0;

--- a/src/cgi.c
+++ b/src/cgi.c
@@ -137,7 +137,7 @@ PUBLIC bool cgiHandler(Webs *wp)
     if (strchr(wp->query, '=') == NULL) {
         query = sclone(wp->query);
         websDecodeUrl(query, query, strlen(query));
-        for (cp = stok(query, " ", &tok); cp != NULL; ) {
+        for (cp = stok(query, " ", &tok); cp != NULL && argp != NULL; ) {
             *(argp+n) = cp;
             trace(5, "ARG[%d] %s", n, argp[n-1]);
             n++;

--- a/src/http.c
+++ b/src/http.c
@@ -1090,12 +1090,12 @@ static void parseHeaders(Webs *wp)
         } else if (strcmp(key, "content-length") == 0) {
             wp->rxLen = atoi(value);
             if (smatch(wp->method, "PUT")) {
-                if (wp->rxLen > ME_GOAHEAD_LIMIT_PUT) {
+                if (wp->rxLen > ME_GOAHEAD_LIMIT_PUT || wp->rxLen < 0) {
                     websError(wp, HTTP_CODE_REQUEST_TOO_LARGE | WEBS_CLOSE, "Too big");
                     return;
                 }
             } else {
-                if (wp->rxLen > ME_GOAHEAD_LIMIT_POST) {
+                if (wp->rxLen > ME_GOAHEAD_LIMIT_POST || wp->rxLen < 0) {
                     websError(wp, HTTP_CODE_REQUEST_TOO_LARGE | WEBS_CLOSE, "Too big");
                     return;
                 }


### PR DESCRIPTION
- Fix two null pointer dereferences in cgi.c (argp may be NULL after walloc/wrealloc calls).
- Add a check around atoi() call that may result in interpreting content-length as a negative number, which could trigger a DoS with chunked encoding.