### PR TITLE
FIXBUG: Fixed the potential segmentation fault issue.

### DIFF
--- a/src/http.c
+++ b/src/http.c
@@ -351,7 +351,7 @@ static void initWebs(Webs *wp, int flags, int reuse)
     WebsBuf     rxbuf;
     void        *ssl;
     char        ipaddr[ME_MAX_IP], ifaddr[ME_MAX_IP];
-    int         wid, sid, timeout;
+    int         wid, sid, timeout, listenSid;
 
     assert(wp);
 
@@ -361,12 +361,14 @@ static void initWebs(Webs *wp, int flags, int reuse)
         sid = wp->sid;
         timeout = wp->timeout;
         ssl = wp->ssl;
+        listenSid = wp->listenSid;
         scopy(ipaddr, sizeof(ipaddr), wp->ipaddr);
         scopy(ifaddr, sizeof(ifaddr), wp->ifaddr);
     } else {
         wid = sid = -1;
         timeout = -1;
         ssl = 0;
+        listenSid = -1;
     }
     memset(wp, 0, sizeof(Webs));
     wp->flags = flags;
@@ -379,6 +381,7 @@ static void initWebs(Webs *wp, int flags, int reuse)
     wp->rxLen = -1;
     wp->code = HTTP_CODE_OK;
     wp->ssl = ssl;
+    wp->listenSid = listenSid;
 #if !ME_ROM
     wp->putfd = -1;
 #endif


### PR DESCRIPTION
Hi, I have found a potential issue that will cause a segmentation fault. Please clone my fork develop repo to duplicate this issue.

The issue description is shown as below.

I implemented a simple dynamic enable/disable API for goahead.
The default will open socket with port 80 and secure socket with port 443.
Open the browser and open the webpage in http and https.
Next, when I used an API to close socket with port 80, the http request will be invalid.
However, if you keep the https request, it will cause the goahead crash.

You can clone my fork develop repo, type "make dev" in your terminal and execute the goahead with src/web.
Next, make sure your browser opens http and https page.
Send an http request as "http://localhost/action/HTTP_DISABLE", and the segmentation fault will happen soon.

The root cause is the http client request in "initWebs" function doesn't cash the variable "listenSid".
In some case, the socketList[0] will be null, and the client request in parseFirstLine function will use this variable(when execute socketGetPort function).

