### PR TITLE
Add missing 'void' parameter for functions which takes no parameters

### DIFF
--- a/src/action.c
+++ b/src/action.c
@@ -89,7 +89,7 @@ static void closeAction()
 }
 
 
-PUBLIC void websActionOpen()
+PUBLIC void websActionOpen(void)
 {
     actionTable = hashCreate(WEBS_HASH_INIT);
     websDefineHandler("action", 0, actionHandler, closeAction, 0);

--- a/src/alloc.c
+++ b/src/alloc.c
@@ -91,7 +91,7 @@ PUBLIC int wopenAlloc(void *buf, int bufsize, int flags)
 }
 
 
-PUBLIC void wcloseAlloc()
+PUBLIC void wcloseAlloc(void)
 {
 #if ME_GOAHEAD_REPLACE_MALLOC
     if (--wopenCount <= 0 && !(controlFlags & WEBS_USER_BUF)) {

--- a/src/auth.c
+++ b/src/auth.c
@@ -169,7 +169,7 @@ PUBLIC int websOpenAuth(int minimal)
 }
 
 
-PUBLIC void websCloseAuth()
+PUBLIC void websCloseAuth(void)
 {
     WebsKey     *key, *next;
 
@@ -400,7 +400,7 @@ static void computeUserAbilities(WebsUser *user)
 }
 
 
-PUBLIC void websComputeAllUserAbilities()
+PUBLIC void websComputeAllUserAbilities(void)
 {
     WebsUser    *user;
     WebsKey     *sym;
@@ -468,13 +468,13 @@ PUBLIC int websRemoveRole(cchar *name)
 }
 
 
-PUBLIC WebsHash websGetUsers()
+PUBLIC WebsHash websGetUsers(void)
 {
     return users;
 }
 
 
-PUBLIC WebsHash websGetRoles()
+PUBLIC WebsHash websGetRoles(void)
 {
     return roles;
 }
@@ -571,7 +571,7 @@ void websSetPasswordStoreVerify(WebsVerify verify)
 }
 
 
-WebsVerify websGetPasswordStoreVerify()
+WebsVerify websGetPasswordStoreVerify(void)
 {
     return verifyPassword;
 }

--- a/src/cgi.c
+++ b/src/cgi.c
@@ -248,7 +248,7 @@ PUBLIC bool cgiHandler(Webs *wp)
 }
 
 
-PUBLIC int websCgiOpen()
+PUBLIC int websCgiOpen(void)
 {
     websDefineHandler("cgi", 0, cgiHandler, 0, 0);
     return 0;
@@ -402,7 +402,7 @@ PUBLIC void websCgiGatherOutput(Cgi *cgip)
     Any entry in the cgiList need to be checked to see if it has completed, and if so, process its output and clean up.
     Return time till next poll.
  */
-int websCgiPoll()
+int websCgiPoll(void)
 {
     Webs    *wp;
     Cgi     *cgip;
@@ -474,7 +474,7 @@ int websCgiPoll()
     Returns a pointer to an allocated qualified unique temporary file name. This filename must eventually be deleted with
     wfree().
  */
-PUBLIC char *websGetCgiCommName()
+PUBLIC char *websGetCgiCommName(void)
 {
     return websTempFile(NULL, "cgi");
 }

--- a/src/file.c
+++ b/src/file.c
@@ -176,7 +176,7 @@ static void fileClose()
 }
 
 
-PUBLIC void websFileOpen()
+PUBLIC void websFileOpen(void)
 {
     websIndex = sclone("index.html");
     websDefineHandler("file", 0, fileHandler, fileClose, 0);
@@ -186,13 +186,13 @@ PUBLIC void websFileOpen()
 /*
     Get the default page for URL requests ending in "/"
  */
-PUBLIC cchar *websGetIndex()
+PUBLIC cchar *websGetIndex(void)
 {
     return websIndex;
 }
 
 
-PUBLIC char *websGetDocuments()
+PUBLIC char *websGetDocuments(void)
 {
     return websDocuments;
 }

--- a/src/fs.c
+++ b/src/fs.c
@@ -20,7 +20,7 @@ static WebsRomIndex *lookup(WebsHash fs, char *path);
 
 /*********************************** Code *************************************/
 
-PUBLIC int websFsOpen()
+PUBLIC int websFsOpen(void)
 {
 #if ME_ROM
     WebsRomIndex    *wip;
@@ -41,7 +41,7 @@ PUBLIC int websFsOpen()
 }
 
 
-PUBLIC void websFsClose()
+PUBLIC void websFsClose(void)
 {
 #if ME_ROM
     hashFree(romFs);

--- a/src/goahead-mbedtls/goahead-mbedtls.c
+++ b/src/goahead-mbedtls/goahead-mbedtls.c
@@ -56,7 +56,7 @@ static void traceMbed(void *context, int level, cchar *file, int line, cchar *st
 
 /************************************** Code **********************************/
 
-PUBLIC int sslOpen()
+PUBLIC int sslOpen(void)
 {
     mbedtls_ssl_config  *conf;
     cuchar              dhm_p[] = MBEDTLS_DHM_RFC3526_MODP_2048_P_BIN;
@@ -197,7 +197,7 @@ PUBLIC int sslOpen()
 }
 
 
-PUBLIC void sslClose()
+PUBLIC void sslClose(void)
 {
     mbedtls_ctr_drbg_free(&cfg.ctr);
     mbedtls_pk_free(&cfg.pkey);

--- a/src/goahead.c
+++ b/src/goahead.c
@@ -24,9 +24,9 @@ static int finished = 0;
 
 /********************************* Forwards ***********************************/
 
-static void initPlatform();
-static void logHeader();
-static void usage();
+static void initPlatform(void);
+static void logHeader(void);
+static void usage(void);
 
 #if WINDOWS
 static void windowsClose();
@@ -177,7 +177,7 @@ MAIN(goahead, int argc, char **argv, char **envp)
 }
 
 
-static void logHeader()
+static void logHeader(void)
 {
     char    home[ME_GOAHEAD_LIMIT_STRING];
 
@@ -196,7 +196,7 @@ static void logHeader()
 }
 
 
-static void usage() {
+static void usage(void) {
     fprintf(stderr, "\n%s Usage:\n\n"
         "  %s [options] [documents] [[IPaddress][:port] ...]\n\n"
         "  Options:\n"
@@ -217,7 +217,7 @@ static void usage() {
 }
 
 
-static void initPlatform()
+static void initPlatform(void)
 {
 #if ME_UNIX_LIKE
     signal(SIGTERM, sigHandler);

--- a/src/goahead.h
+++ b/src/goahead.h
@@ -239,20 +239,20 @@ PUBLIC void error(cchar *fmt, ...);
     @return Zero if successful
     @internal
  */
-PUBLIC int logOpen();
+PUBLIC int logOpen(void);
 
 /**
     Close the log logging module
     @internal
  */
-PUBLIC void logClose();
+PUBLIC void logClose(void);
 
 /**
     Get the  log callback
     @return handler Callback handler function of type WebsLogHandler
     @stability Stable
  */
-PUBLIC WebsLogHandler logGetHandler();
+PUBLIC WebsLogHandler logGetHandler(void);
 
 /**
     Set a log callback
@@ -268,7 +268,7 @@ PUBLIC WebsLogHandler logSetHandler(WebsLogHandler handler);
     @ingroup Webs
     @stability Stable
  */
-PUBLIC int websGetLogLevel();
+PUBLIC int websGetLogLevel(void);
 
 /**
     Set the current trace log level
@@ -764,7 +764,7 @@ typedef struct WebsAlloc {
     @ingroup WebsAlloc
     @stability Stable
  */
-PUBLIC void wcloseAlloc();
+PUBLIC void wcloseAlloc(void);
 
 /**
     Initialize the walloc module.
@@ -1079,7 +1079,7 @@ PUBLIC int socketAlloc(cchar *host, int port, SocketAccept accept, int flags);
     @ingroup WebsSocket
     @stability Stable
  */
-PUBLIC void socketClose();
+PUBLIC void socketClose(void);
 
 /**
     Close a socket connection
@@ -1171,7 +1171,7 @@ PUBLIC Socket socketGetHandle(int sid);
     @ingroup WebsSocket
     @stability Stable
  */
-PUBLIC WebsSocket **socketGetList();
+PUBLIC WebsSocket **socketGetList(void);
 
 /**
     Get the IP port associated with this socket.
@@ -1188,7 +1188,7 @@ PUBLIC int socketGetPort(int sid);
     @ingroup WebsSocket
     @stability Stable
  */
-PUBLIC bool socketHasDualNetworkStack();
+PUBLIC bool socketHasDualNetworkStack(void);
 
 /**
     Indicate if the system has IPv6 support
@@ -1196,7 +1196,7 @@ PUBLIC bool socketHasDualNetworkStack();
     @ingroup WebsSocket
     @stability Stable
  */
-PUBLIC bool socketHasIPv6();
+PUBLIC bool socketHasIPv6(void);
 
 /**
     Indicate that the application layer has buffered data for the socket.
@@ -1251,7 +1251,7 @@ PUBLIC int socketListen(cchar *host, int port, SocketAccept accept, int flags);
     @ingroup WebsSocket
     @stability Stable
  */
-PUBLIC int socketOpen();
+PUBLIC int socketOpen(void);
 
 /**
     Parse an IP address into its constituent parts.
@@ -1280,7 +1280,7 @@ PUBLIC int socketParseAddress(cchar *ipAddrPort, char **pip, int *pport, int *se
     @stability Stable
     @internal
  */
-PUBLIC void socketProcess();
+PUBLIC void socketProcess(void);
 
 /**
     Read data from a socket
@@ -1760,7 +1760,7 @@ PUBLIC void websRestartEvent(int id, int delay);
     @return Time delay till the next event
     @internal
  */
-PUBLIC int websRunEvents();
+PUBLIC int websRunEvents(void);
 
 /* Forward declare */
 struct WebsRoute;
@@ -1788,7 +1788,7 @@ typedef struct WebsUpload {
     @ingroup WebsUpload
     @stability Stable
  */
-PUBLIC void websUploadOpen();
+PUBLIC void websUploadOpen(void);
 
 /**
     Get the hash of uploaded files for the request
@@ -2005,7 +2005,7 @@ typedef bool (*WebsHandlerProc)(Webs *wp);
     @ingroup Webs
     @stability Stable
  */
-typedef void (*WebsHandlerClose)();
+typedef void (*WebsHandlerClose)(void);
 
 /**
     GoAhead handler object
@@ -2103,7 +2103,7 @@ PUBLIC int websAccept(int sid, cchar *ipaddr, int port, int listenSid);
     @ingroup Webs
     @stability Stable
  */
-PUBLIC void websActionOpen();
+PUBLIC void websActionOpen(void);
 
 /**
     Allocate a new Webs object
@@ -2131,7 +2131,7 @@ PUBLIC void websCancelTimeout(Webs *wp);
     @ingroup Webs
     @stability Stable
  */
-PUBLIC int websCgiOpen();
+PUBLIC int websCgiOpen(void);
 
 /**
     CGI handler service callback
@@ -2148,7 +2148,7 @@ PUBLIC int websCgiHandler(Webs *wp);
     @ingroup Webs
     @stability Stable
  */
-PUBLIC int websCgiPoll();
+PUBLIC int websCgiPoll(void);
 
 /* Internal */
 PUBLIC bool cgiHandler(Webs *wp);
@@ -2161,7 +2161,7 @@ PUBLIC bool cgiHandler(Webs *wp);
     @ingroup Webs
     @stability Stable
  */
-PUBLIC void websClose();
+PUBLIC void websClose(void);
 
 /**
     Close an open file
@@ -2304,7 +2304,7 @@ PUBLIC cchar *websErrorMsg(int code);
     @ingroup Webs
     @stability Stable
  */
-PUBLIC void websFileOpen();
+PUBLIC void websFileOpen(void);
 
 /**
     Flush buffered transmit data and compact the transmit buffer to make room for more data
@@ -2337,7 +2337,7 @@ PUBLIC void websFree(Webs *wp);
     @ingroup Webs
     @stability Stable
  */
-PUBLIC int websGetBackground();
+PUBLIC int websGetBackground(void);
 
 #if ME_GOAHEAD_CGI
 /**
@@ -2346,7 +2346,7 @@ PUBLIC int websGetBackground();
     @ingroup Webs
     @stability Stable
  */
-PUBLIC char *websGetCgiCommName();
+PUBLIC char *websGetCgiCommName(void);
 #endif /* ME_GOAHEAD_CGI */
 
 /**
@@ -2375,7 +2375,7 @@ PUBLIC char *websGetDateString(WebsFileInfo *sbuf);
     @ingroup Webs
     @stability Stable
  */
-PUBLIC int websGetDebug();
+PUBLIC int websGetDebug(void);
 
 /**
     Get the base file directory for a request
@@ -2394,7 +2394,7 @@ PUBLIC cchar *websGetDir(Webs *wp);
     @ingroup Webs
     @stability Stable
  */
-PUBLIC char *websGetDocuments();
+PUBLIC char *websGetDocuments(void);
 
 /**
     Get the request EOF status
@@ -2452,7 +2452,7 @@ PUBLIC cchar *websGetIfaddr(Webs *wp);
     @ingroup Webs
     @stability Stable
  */
-PUBLIC cchar *websGetIndex();
+PUBLIC cchar *websGetIndex(void);
 
 /**
     Get the request method
@@ -2519,7 +2519,7 @@ PUBLIC cchar *websGetQuery(Webs *wp);
     @ingroup Webs
     @stability Stable
  */
-PUBLIC cchar *websGetServer();
+PUBLIC cchar *websGetServer(void);
 
 /**
     Get the server host name with port number.
@@ -2527,7 +2527,7 @@ PUBLIC cchar *websGetServer();
     @ingroup Webs
     @stability Stable
  */
-PUBLIC cchar *websGetServerUrl();
+PUBLIC cchar *websGetServerUrl(void);
 
 /**
     Get the server IP address
@@ -2535,7 +2535,7 @@ PUBLIC cchar *websGetServerUrl();
     @ingroup Webs
     @stability Stable
  */
-PUBLIC cchar *websGetServerAddress();
+PUBLIC cchar *websGetServerAddress(void);
 
 /**
     Get the server IP address with port number
@@ -2543,7 +2543,7 @@ PUBLIC cchar *websGetServerAddress();
     @ingroup Webs
     @stability Stable
  */
-PUBLIC cchar *websGetServerAddressUrl();
+PUBLIC cchar *websGetServerAddressUrl(void);
 
 /**
     Get the request URI
@@ -2643,7 +2643,7 @@ PUBLIC void websNoteRequestActivity(Webs *wp);
     @ingroup Webs
     @internal
  */
-PUBLIC void websRuntimeClose();
+PUBLIC void websRuntimeClose(void);
 
 /**
     Open the runtime code.
@@ -2652,7 +2652,7 @@ PUBLIC void websRuntimeClose();
     @ingroup Webs
     @internal
  */
-PUBLIC int websRuntimeOpen();
+PUBLIC int websRuntimeOpen(void);
 
 /**
     Open the web server
@@ -2674,7 +2674,7 @@ PUBLIC int websOpen(cchar *documents, cchar *routes);
     @ingroup Webs
     @internal
  */
-PUBLIC void websOsClose();
+PUBLIC void websOsClose(void);
 
 /**
     Open the O/S dependant code.
@@ -2683,7 +2683,7 @@ PUBLIC void websOsClose();
     @ingroup Webs
     @internal
  */
-PUBLIC int websOsOpen();
+PUBLIC int websOsOpen(void);
 
 /**
     Open the web page document for the current request
@@ -2702,7 +2702,7 @@ PUBLIC int websOpenFile(cchar *path, int flags, int mode);
     @ingroup Webs
     @stability Stable
  */
-PUBLIC int websOptionsOpen();
+PUBLIC int websOptionsOpen(void);
 
 /**
     Close the document page
@@ -2869,14 +2869,14 @@ PUBLIC int websRewriteRequest(Webs *wp, cchar *url);
     @ingroup Webs
     @stability Stable
  */
-PUBLIC int websFsOpen();
+PUBLIC int websFsOpen(void);
 
 /**
     Close the file system module
     @ingroup Webs
     @stability Stable
  */
-PUBLIC void websFsClose();
+PUBLIC void websFsClose(void);
 
 /**
     Seek to a position in the current request page document
@@ -3097,14 +3097,14 @@ PUBLIC char *websTempFile(cchar *dir, cchar *prefix);
     @ingroup Webs
     @stability Evolving
  */
-PUBLIC int websTimeOpen();
+PUBLIC int websTimeOpen(void);
 
 /**
     Close the date/time parsing module
     @ingroup Webs
     @stability Evolving
 */
-PUBLIC void websTimeClose();
+PUBLIC void websTimeClose(void);
 
 /**
     Parse a date/time string
@@ -3401,7 +3401,7 @@ PUBLIC int websDefineJst(cchar *name, WebsJstProc fn);
     @ingroup Webs
     @stability Stable
  */
-PUBLIC int websJstOpen();
+PUBLIC int websJstOpen(void);
 
 /**
     Write data to the response
@@ -3465,14 +3465,14 @@ PUBLIC int websJstWrite(int jid, Webs *wp, int argc, char **argv);
     @ingroup Webs
     @stability Stable
  */
-PUBLIC int sslOpen();
+PUBLIC int sslOpen(void);
 
 /**
     Close the ssl module
     @ingroup Webs
     @stability Stable
  */
-PUBLIC void sslClose();
+PUBLIC void sslClose(void);
 
 /**
     Free a ssl connection associated with a request
@@ -3580,7 +3580,7 @@ PUBLIC WebsRoute *websAddRoute(cchar *uri, cchar *handler, int pos);
     @ingroup WebsRoute
     @stability Stable
  */
-PUBLIC void websCloseRoute();
+PUBLIC void websCloseRoute(void);
 
 /**
     Load routing tables from the specified filename
@@ -3596,7 +3596,7 @@ PUBLIC int websLoad(cchar *path);
     @ingroup WebsRoute
     @stability Stable
  */
-PUBLIC int websOpenRoute();
+PUBLIC int websOpenRoute(void);
 
 /**
     Remove a route from the routing tables
@@ -3735,14 +3735,14 @@ PUBLIC bool websCan(Webs *wp, WebsHash ability);
     @ingroup WebsAuth
     @stability Stable
  */
-PUBLIC void websCloseAuth();
+PUBLIC void websCloseAuth(void);
 
 /**
     Compute the abilities for all users by resolving roles into abilities
     @ingroup WebsAuth
     @stability Stable
  */
-PUBLIC void websComputeAllUserAbilities();
+PUBLIC void websComputeAllUserAbilities(void);
 
 /**
     Set the password store verify callback
@@ -3750,7 +3750,7 @@ PUBLIC void websComputeAllUserAbilities();
     @ingroup WebsAuth
     @stability Stable
  */
-PUBLIC WebsVerify websGetPasswordStoreVerify();
+PUBLIC WebsVerify websGetPasswordStoreVerify(void);
 
 /**
     Get the roles hash
@@ -3758,7 +3758,7 @@ PUBLIC WebsVerify websGetPasswordStoreVerify();
     @ingroup WebsAuth
     @stability Stable
  */
-PUBLIC WebsHash websGetRoles();
+PUBLIC WebsHash websGetRoles(void);
 
 /**
     Get the users hash
@@ -3766,7 +3766,7 @@ PUBLIC WebsHash websGetRoles();
     @ingroup WebsAuth
     @stability Stable
  */
-PUBLIC WebsHash websGetUsers();
+PUBLIC WebsHash websGetUsers(void);
 
 /**
     Login a user by verifying the login credentials.

--- a/src/http.c
+++ b/src/http.c
@@ -200,13 +200,13 @@ static void     parseFirstLine(Webs *wp);
 static void     parseHeaders(Webs *wp);
 static bool     processContent(Webs *wp);
 static bool     parseIncoming(Webs *wp);
-static void     pruneSessions();
+static void     pruneSessions(void);
 static void     freeSession(WebsSession *sp);
-static void     freeSessions();
+static void     freeSessions(void);
 static void     readEvent(Webs *wp);
 static void     reuseConn(Webs *wp);
-static void     setFileLimits();
-static int      setLocalHost();
+static void     setFileLimits(void);
+static int      setLocalHost(void);
 static void     socketEvent(int sid, int mask, void *data);
 static void     writeEvent(Webs *wp);
 #if ME_GOAHEAD_ACCESS_LOG
@@ -290,7 +290,7 @@ PUBLIC int websOpen(cchar *documents, cchar *routeFile)
 }
 
 
-PUBLIC void websClose()
+PUBLIC void websClose(void)
 {
     Webs    *wp;
     int     i;
@@ -2344,7 +2344,7 @@ static void checkTimeout(void *arg, int id)
 }
 
 
-static int setLocalHost()
+static int setLocalHost(void)
 {
     struct in_addr  intaddr;
     char            host[128], *ipaddr;
@@ -2976,7 +2976,7 @@ static char *getToken(Webs *wp, char *delim)
 }
 
 
-PUBLIC int websGetBackground()
+PUBLIC int websGetBackground(void)
 {
     return websBackground;
 }
@@ -2988,7 +2988,7 @@ PUBLIC void websSetBackground(int on)
 }
 
 
-PUBLIC int websGetDebug()
+PUBLIC int websGetDebug(void)
 {
     return websDebug;
 }
@@ -3217,7 +3217,7 @@ PUBLIC int websSetSessionVar(Webs *wp, cchar *key, cchar *value)
 }
 
 
-static void pruneSessions()
+static void pruneSessions(void)
 {
     WebsSession     *sp;
     WebsTime        when;
@@ -3244,7 +3244,7 @@ static void pruneSessions()
 }
 
 
-static void freeSessions()
+static void freeSessions(void)
 {
     WebsSession     *sp;
     WebsKey         *sym, *next;
@@ -3287,7 +3287,7 @@ PUBLIC int websServer(cchar *endpoint, cchar *documents)
 }
 
 
-static void setFileLimits()
+static void setFileLimits(void)
 {
 #if ME_UNIX_LIKE
     struct rlimit r;
@@ -3411,10 +3411,10 @@ PUBLIC cchar *websGetPath(Webs *wp) { return wp->path; }
 PUBLIC int   websGetPort(Webs *wp) { return wp->port; }
 PUBLIC cchar *websGetProtocol(Webs *wp) { return wp->protocol; }
 PUBLIC cchar *websGetQuery(Webs *wp) { return wp->query; }
-PUBLIC cchar *websGetServer() { return websHost; }
-PUBLIC cchar *websGetServerAddress() { return websIpAddr; }
-PUBLIC cchar *websGetServerAddressUrl() { return websIpAddrUrl; }
-PUBLIC cchar *websGetServerUrl() { return websHostUrl; }
+PUBLIC cchar *websGetServer(void) { return websHost; }
+PUBLIC cchar *websGetServerAddress(void) { return websIpAddr; }
+PUBLIC cchar *websGetServerAddressUrl(void) { return websIpAddrUrl; }
+PUBLIC cchar *websGetServerUrl(void) { return websHostUrl; }
 PUBLIC cchar *websGetUrl(Webs *wp) { return wp->url; }
 PUBLIC cchar *websGetUserAgent(Webs *wp) { return wp->userAgent; }
 PUBLIC cchar *websGetUsername(Webs *wp) { return wp->username; }

--- a/src/jst.c
+++ b/src/jst.c
@@ -164,7 +164,7 @@ done:
 }
 
 
-static void closeJst()
+static void closeJst(void)
 {
     if (websJstFunctions != -1) {
         hashFree(websJstFunctions);
@@ -173,7 +173,7 @@ static void closeJst()
 }
 
 
-PUBLIC int websJstOpen()
+PUBLIC int websJstOpen(void)
 {
     websJstFunctions = hashCreate(WEBS_HASH_INIT * 2);
     websDefineJst("write", websJstWrite);

--- a/src/options.c
+++ b/src/options.c
@@ -41,7 +41,7 @@ static bool optionsHandler(Webs *wp)
 }
 
 
-PUBLIC int websOptionsOpen()
+PUBLIC int websOptionsOpen(void)
 {
     websDefineHandler("options", 0, optionsHandler, 0, 0);
     return 0;

--- a/src/osdep.c
+++ b/src/osdep.c
@@ -17,7 +17,7 @@
 
 /************************************* Code ***********************************/
 
-PUBLIC int websOsOpen()
+PUBLIC int websOsOpen(void)
 {
 #if SOLARIS
     openlog(ME_NAME, LOG_LOCAL0);
@@ -33,7 +33,7 @@ PUBLIC int websOsOpen()
 }
 
 
-PUBLIC void websOsClose()
+PUBLIC void websOsClose(void)
 {
 #if ME_UNIX_LIKE
     closelog();

--- a/src/route.c
+++ b/src/route.c
@@ -29,7 +29,7 @@ static int routeMax = 0;
 
 static bool continueHandler(Webs *wp);
 static void freeRoute(WebsRoute *route);
-static void growRoutes();
+static void growRoutes(void);
 static int lookupRoute(cchar *uri);
 static bool redirectHandler(Webs *wp);
 
@@ -340,7 +340,7 @@ PUBLIC int websSetRouteMatch(WebsRoute *route, cchar *dir, cchar *protocol, Webs
 }
 
 
-static void growRoutes()
+static void growRoutes(void)
 {
     if (routeCount >= routeMax) {
         routeMax += 16;
@@ -410,7 +410,7 @@ PUBLIC int websRemoveRoute(cchar *uri)
 }
 
 
-PUBLIC int websOpenRoute()
+PUBLIC int websOpenRoute(void)
 {
     if ((handlers = hashCreate(-1)) < 0) {
         return -1;
@@ -421,7 +421,7 @@ PUBLIC int websOpenRoute()
 }
 
 
-PUBLIC void websCloseRoute()
+PUBLIC void websCloseRoute(void)
 {
     WebsHandler *handler;
     WebsKey     *key;

--- a/src/runtime.c
+++ b/src/runtime.c
@@ -204,7 +204,7 @@ static void outFloat(Format *fmt, char specChar, double value);
 
 /************************************* Code ***********************************/
 
-PUBLIC int websRuntimeOpen()
+PUBLIC int websRuntimeOpen(void)
 {
     symMax = 0;
     sym = 0;
@@ -213,7 +213,7 @@ PUBLIC int websRuntimeOpen()
 }
 
 
-PUBLIC void websRuntimeClose()
+PUBLIC void websRuntimeClose(void)
 {
 }
 
@@ -280,7 +280,7 @@ PUBLIC void websStopEvent(int id)
 }
 
 
-int websRunEvents()
+int websRunEvents(void)
 {
     Callback    *s;
     WebsTime    now;
@@ -1040,7 +1040,7 @@ PUBLIC void traceProc(int level, cchar *fmt, ...)
 }
 
 
-PUBLIC int websGetLogLevel()
+PUBLIC int websGetLogLevel(void)
 {
     return logLevel;
 }
@@ -1052,7 +1052,7 @@ void websSetLogLevel(int level)
 }
 
 
-WebsLogHandler logGetHandler()
+WebsLogHandler logGetHandler(void)
 {
     return logHandler;
 }
@@ -1073,7 +1073,7 @@ WebsLogHandler logSetHandler(WebsLogHandler handler)
 }
 
 
-PUBLIC int logOpen()
+PUBLIC int logOpen(void)
 {
     if (!logPath) {
         /* This defintion comes from main.me goahead.logfile */
@@ -1096,7 +1096,7 @@ PUBLIC int logOpen()
 }
 
 
-PUBLIC void logClose()
+PUBLIC void logClose(void)
 {
 #if !ME_ROM
     if (logFd > 2) {

--- a/src/socket.c
+++ b/src/socket.c
@@ -25,7 +25,7 @@ static void socketDoEvent(WebsSocket *sp);
 
 /*********************************** Code *************************************/
 
-PUBLIC int socketOpen()
+PUBLIC int socketOpen(void)
 {
     Socket  fd;
 
@@ -58,7 +58,7 @@ PUBLIC int socketOpen()
 }
 
 
-PUBLIC void socketClose()
+PUBLIC void socketClose(void)
 {
     int     i;
 
@@ -73,7 +73,7 @@ PUBLIC void socketClose()
 }
 
 
-PUBLIC bool socketHasDualNetworkStack()
+PUBLIC bool socketHasDualNetworkStack(void)
 {
     bool dual;
 
@@ -86,7 +86,7 @@ PUBLIC bool socketHasDualNetworkStack()
 }
 
 
-PUBLIC bool socketHasIPv6()
+PUBLIC bool socketHasIPv6(void)
 {
     return hasIPv6;
 }
@@ -614,7 +614,7 @@ PUBLIC int socketSelect(int sid, int timeout)
 #endif /* WINDOWS || CE */
 
 
-PUBLIC void socketProcess()
+PUBLIC void socketProcess(void)
 {
     WebsSocket    *sp;
     int         sid;
@@ -1376,7 +1376,7 @@ PUBLIC bool socketAddressIsV6(cchar *ip)
 }
 
 
-PUBLIC WebsSocket **socketGetList()
+PUBLIC WebsSocket **socketGetList(void)
 {
     return socketList;
 }

--- a/src/time.c
+++ b/src/time.c
@@ -133,7 +133,7 @@ static void validateTime(struct tm *tm, struct tm *defaults);
 
 /************************************ Code ************************************/
 
-PUBLIC int websTimeOpen()
+PUBLIC int websTimeOpen(void)
 {
     TimeToken           *tt;
 
@@ -163,7 +163,7 @@ PUBLIC int websTimeOpen()
 }
 
 
-PUBLIC void websTimeClose()
+PUBLIC void websTimeClose(void)
 {
     if (timeTokens >= 0) {
         hashFree(timeTokens);

--- a/src/upload.c
+++ b/src/upload.c
@@ -450,7 +450,7 @@ WebsHash websGetUpload(Webs *wp)
 }
 
 
-PUBLIC void websUploadOpen()
+PUBLIC void websUploadOpen(void)
 {
     uploadDir = ME_GOAHEAD_UPLOAD_DIR;
     if (*uploadDir == '\0') {

--- a/src/utils/gopass.c
+++ b/src/utils/gopass.c
@@ -17,8 +17,8 @@
 
 /********************************* Forwards ***********************************/
 
-static char *getPassword();
-static void printUsage();
+static char *getPassword(void);
+static void printUsage(void);
 static int writeAuthFile(char *path);
 
 #if ME_WIN_LIKE || VXWORKS
@@ -186,7 +186,7 @@ static int writeAuthFile(char *path)
 }
 
 
-static char *getPassword()
+static char *getPassword(void)
 {
     char    *password, *confirm;
 
@@ -255,7 +255,7 @@ static char *getpass(char *prompt)
     Display the usage
  */
 
-static void printUsage()
+static void printUsage(void)
 {
     error("usage: gopass [--cipher cipher] [--file path] [--password password] realm user roles...\n"
         "Options:\n"

--- a/test/test.c
+++ b/test/test.c
@@ -42,9 +42,9 @@ static int finished = 0;
 
 /********************************* Forwards ***********************************/
 
-static void initPlatform();
-static void logHeader();
-static void usage();
+static void initPlatform(void);
+static void logHeader(void);
+static void usage(void);
 
 static bool testHandler(Webs *wp);
 #if ME_GOAHEAD_JAVASCRIPT
@@ -209,7 +209,7 @@ static void exitProc(void *data, int id)
 }
 
 
-static void logHeader()
+static void logHeader(void)
 {
     char    home[ME_GOAHEAD_LIMIT_STRING];
 
@@ -228,7 +228,7 @@ static void logHeader()
 }
 
 
-static void usage() {
+static void usage(void) {
     fprintf(stderr, "\n%s Usage:\n\n"
         "  %s [options] [documents] [IPaddress][:port]...\n\n"
         "  Options:\n"
@@ -247,7 +247,7 @@ static void usage() {
 }
 
 
-void initPlatform()
+void initPlatform(void)
 {
 #if ME_UNIX_LIKE
     signal(SIGINT, sigHandler);


### PR DESCRIPTION
The only safe way in C to declare a function which takes no parameters is by specifying a 'void' parameter.

`int foo()` means a function which takes an unspecified number of arguments of unspecified type and is declared an obsolescent feature in C99.